### PR TITLE
Feature add in background torch control

### DIFF
--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -45,13 +45,12 @@ public final class CameraView: UIView, CameraSessionDelegate {
   // other props
   @objc var isActive = false
   @objc var torch = "off"
-  @objc var torchLevel: NSNumber = 0.7
+  @objc var torchLevel: NSNumber = 0
   @objc var torchDelay: NSNumber = 0
   @objc var torchDuration: NSNumber = 0
-  @objc var backgroundLevel: NSNumber = 0.0
+  @objc var backgroundLevel: NSNumber = 0
   @objc var backgroundDelay: NSNumber = 0
   @objc var backgroundDuration: NSNumber = 0
-  @objc var enableBackgroundTorch = false
   @objc var isTorchOn = false
   @objc var zoom: NSNumber = 1.0 // in "factor"
   @objc var exposure: NSNumber = 1.0
@@ -242,7 +241,6 @@ public final class CameraView: UIView, CameraSessionDelegate {
       config.backgroundLevel = backgroundLevel.doubleValue as NSNumber
       config.backgroundDelay = backgroundDelay.doubleValue as NSNumber
       config.backgroundDuration = backgroundDuration.doubleValue as NSNumber
-      config.enableBackgroundTorch = true
 
       // Zoom
       config.zoom = zoom.doubleValue

--- a/package/ios/CameraView.swift
+++ b/package/ios/CameraView.swift
@@ -45,6 +45,14 @@ public final class CameraView: UIView, CameraSessionDelegate {
   // other props
   @objc var isActive = false
   @objc var torch = "off"
+  @objc var torchLevel: NSNumber = 0.7
+  @objc var torchDelay: NSNumber = 0
+  @objc var torchDuration: NSNumber = 0
+  @objc var backgroundLevel: NSNumber = 0.0
+  @objc var backgroundDelay: NSNumber = 0
+  @objc var backgroundDuration: NSNumber = 0
+  @objc var enableBackgroundTorch = false
+  @objc var isTorchOn = false
   @objc var zoom: NSNumber = 1.0 // in "factor"
   @objc var exposure: NSNumber = 1.0
   @objc var enableFpsGraph = false
@@ -228,6 +236,13 @@ public final class CameraView: UIView, CameraSessionDelegate {
       config.fps = fps?.int32Value
       config.enableLowLightBoost = lowLightBoost
       config.torch = try Torch(jsValue: torch)
+      config.torchLevel = torchLevel.doubleValue as NSNumber
+      config.torchDelay = torchDelay.doubleValue as NSNumber
+      config.torchDuration = torchDuration.doubleValue as NSNumber
+      config.backgroundLevel = backgroundLevel.doubleValue as NSNumber
+      config.backgroundDelay = backgroundDelay.doubleValue as NSNumber
+      config.backgroundDuration = backgroundDuration.doubleValue as NSNumber
+      config.enableBackgroundTorch = true
 
       // Zoom
       config.zoom = zoom.doubleValue

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -49,7 +49,6 @@ RCT_EXPORT_VIEW_PROPERTY(torchDuration, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(backgroundLevel, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(backgroundDelay, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(backgroundDuration, NSNumber);
-RCT_EXPORT_VIEW_PROPERTY(enableBackgroundTorch, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(zoom, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(exposure, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(enableZoomGesture, BOOL);

--- a/package/ios/CameraViewManager.m
+++ b/package/ios/CameraViewManager.m
@@ -43,6 +43,13 @@ RCT_EXPORT_VIEW_PROPERTY(videoStabilizationMode, NSString);
 RCT_EXPORT_VIEW_PROPERTY(pixelFormat, NSString);
 // other props
 RCT_EXPORT_VIEW_PROPERTY(torch, NSString);
+RCT_EXPORT_VIEW_PROPERTY(torchLevel, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(torchDelay, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(torchDuration, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(backgroundLevel, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(backgroundDelay, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(backgroundDuration, NSNumber);
+RCT_EXPORT_VIEW_PROPERTY(enableBackgroundTorch, BOOL);
 RCT_EXPORT_VIEW_PROPERTY(zoom, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(exposure, NSNumber);
 RCT_EXPORT_VIEW_PROPERTY(enableZoomGesture, BOOL);

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -35,13 +35,12 @@ class CameraConfiguration {
   var fps: Int32?
   var enableLowLightBoost = false
   var torch: Torch = .off
-  var torchLevel: NSNumber = 0.7
+  var torchLevel: NSNumber = 0
   var torchDelay: NSNumber = 0
   var torchDuration: NSNumber = 0
-  var backgroundLevel: NSNumber = 0.0
+  var backgroundLevel: NSNumber = 0
   var backgroundDelay: NSNumber = 0
   var backgroundDuration: NSNumber = 0
-  var enableBackgroundTorch = false
   var isTorchOn = false
 
   // Zoom
@@ -75,7 +74,6 @@ class CameraConfiguration {
       backgroundLevel = other.backgroundLevel
       backgroundDelay = other.backgroundDelay
       backgroundDuration = other.backgroundDuration
-      enableBackgroundTorch = other.enableBackgroundTorch
       zoom = other.zoom
       exposure = other.exposure
       isActive = other.isActive

--- a/package/ios/Core/CameraConfiguration.swift
+++ b/package/ios/Core/CameraConfiguration.swift
@@ -35,6 +35,14 @@ class CameraConfiguration {
   var fps: Int32?
   var enableLowLightBoost = false
   var torch: Torch = .off
+  var torchLevel: NSNumber = 0.7
+  var torchDelay: NSNumber = 0
+  var torchDuration: NSNumber = 0
+  var backgroundLevel: NSNumber = 0.0
+  var backgroundDelay: NSNumber = 0
+  var backgroundDuration: NSNumber = 0
+  var enableBackgroundTorch = false
+  var isTorchOn = false
 
   // Zoom
   var zoom: CGFloat?
@@ -61,6 +69,13 @@ class CameraConfiguration {
       fps = other.fps
       enableLowLightBoost = other.enableLowLightBoost
       torch = other.torch
+      torchLevel = other.torchLevel
+      torchDelay = other.torchDelay
+      torchDuration = other.torchDuration
+      backgroundLevel = other.backgroundLevel
+      backgroundDelay = other.backgroundDelay
+      backgroundDuration = other.backgroundDuration
+      enableBackgroundTorch = other.enableBackgroundTorch
       zoom = other.zoom
       exposure = other.exposure
       isActive = other.isActive

--- a/package/ios/Core/CameraSession+Video.swift
+++ b/package/ios/Core/CameraSession+Video.swift
@@ -164,7 +164,7 @@ extension CameraSession {
         var torchEnd = DispatchTimeInterval.milliseconds(Int(self.configuration!.torchDelay) + Int(self.configuration!.torchDuration))
 
         if let backgroundLevelValue = self.configuration!.backgroundLevel as? Double {
-          if backgroundLevelValue > 0.0 && self.configuration!.enableBackgroundTorch && Int(self.configuration!.backgroundDelay) > 0 {
+          if backgroundLevelValue > 0.0 && Int(self.configuration!.backgroundDelay) > 0 {
             DispatchQueue.main.asyncAfter(deadline: .now() + backgroundDelay) {
               self.recordingTimestamps.requestBackgroundTorchOnAt = NSDate().timeIntervalSince1970
               self.setBackgroundLight(self.configuration!.backgroundLevel, torchMode: "on")
@@ -190,7 +190,7 @@ extension CameraSession {
             self.recordingTimestamps.requestTorchOffAt = NSDate().timeIntervalSince1970
             self.setTorchMode("off", torchLevelVal: self.configuration!.torchLevel)
             if let backgroundLevelValue = self.configuration!.backgroundLevel as? Double {
-              if backgroundLevelValue > 0.0 && self.configuration!.enableBackgroundTorch && Int(self.configuration!.backgroundDelay) > 0 {
+              if backgroundLevelValue > 0.0 && Int(self.configuration!.backgroundDelay) > 0 {
                 self.setBackgroundLight(self.configuration!.backgroundLevel, torchMode: "on")
               }
             }

--- a/package/ios/Core/CameraSession.swift
+++ b/package/ios/Core/CameraSession.swift
@@ -31,6 +31,8 @@ class CameraSession: NSObject, AVCaptureVideoDataOutputSampleBufferDelegate, AVC
   var recordingSession: RecordingSession?
   var isRecording = false
 
+  var recordingTimestamps = RecordingTimestamps()
+
   // Callbacks
   weak var delegate: CameraSessionDelegate?
 

--- a/package/ios/Types/Video.swift
+++ b/package/ios/Types/Video.swift
@@ -22,11 +22,14 @@ struct Video {
    * The size of the video, in pixels.
    */
   var size: CGSize
+  // FAHAD
+  var metadata: [String: Double?]
 
   func toJSValue() -> NSDictionary {
     return [
       "path": path,
       "duration": duration,
+      "metadata": metadata,
       "width": size.width,
       "height": size.height,
     ]

--- a/package/ios/Types/Video.swift
+++ b/package/ios/Types/Video.swift
@@ -22,7 +22,10 @@ struct Video {
    * The size of the video, in pixels.
    */
   var size: CGSize
-  // FAHAD
+    
+  /**
+   * Extra info for storing date time for record on / off
+   */
   var metadata: [String: Double?]
 
   func toJSValue() -> NSDictionary {

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -98,7 +98,7 @@ export interface CameraProps extends ViewProps {
    */
   torchLevel?: number
   /**
-   * Specifies the a delay before the torch turns on during a recording session
+   * Specifies a delay before the torch turns on during a recording session.
    *
    * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
    *
@@ -106,7 +106,7 @@ export interface CameraProps extends ViewProps {
    */
   torchDelay?: number
   /**
-   * Specifies the amount of time the torch is on during a recording session
+   * Specifies the duration for which the torch is on during a recording session.
    *
    * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
    *
@@ -114,14 +114,14 @@ export interface CameraProps extends ViewProps {
    */
   torchDuration?: number
   /**
-   * Specifies the background torch level of the current camera. This value ranges from 0.0 to 1.0
+   * Specifies the background torch level of the current camera. This value ranges from 0.0 to 1.0.
    *
    * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
    *
    */
   backgroundLevel?: number
   /**
-   * Specifies the a delay before the background torch turns on during a recording session
+   * Specifies a delay before the background torch turns on during a recording session.
    *
    * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
    *
@@ -129,7 +129,7 @@ export interface CameraProps extends ViewProps {
    */
   backgroundDelay?: number
   /**
-   * Specifies the amount of time the background torch is on during a recording session
+   * Specifies the duration for which the background torch is on during a recording session.
    *
    * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
    *

--- a/package/src/CameraProps.ts
+++ b/package/src/CameraProps.ts
@@ -91,6 +91,52 @@ export interface CameraProps extends ViewProps {
    */
   torch?: 'off' | 'on'
   /**
+   * Specifies the torch level of the current camera. This value ranges from 0.0 to 1.0
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   */
+  torchLevel?: number
+  /**
+   * Specifies the a delay before the torch turns on during a recording session
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   * @default 0
+   */
+  torchDelay?: number
+  /**
+   * Specifies the amount of time the torch is on during a recording session
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   * @default 0
+   */
+  torchDuration?: number
+  /**
+   * Specifies the background torch level of the current camera. This value ranges from 0.0 to 1.0
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   */
+  backgroundLevel?: number
+  /**
+   * Specifies the a delay before the background torch turns on during a recording session
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   * @default 0
+   */
+  backgroundDelay?: number
+  /**
+   * Specifies the amount of time the background torch is on during a recording session
+   *
+   * Make sure the given {@linkcode device} has a torch (see {@linkcode CameraDevice.hasTorch device.hasTorch}).
+   *
+   * @default 0
+   */
+  backgroundDuration?: number
+  /**
    * Specifies the zoom factor of the current camera, in "factor"/scale.
    *
    * This value ranges from `minZoom` (e.g. `1`) to `maxZoom` (e.g. `128`). It is recommended to set this value


### PR DESCRIPTION
Changes to code to allow devs to control background torch when the camera is on

<!--
                    ❤️ Thank you for your contribution! ❤️
              Make sure you have read the Contributing Guidelines:
  https://github.com/mrousavy/react-native-vision-camera/blob/main/CONTRIBUTING.md
-->

## What
This PR adds capacity to control the timing and intensity of the torch during video recording. It allows the developer to specify Camera props that will activate the torch at two different levels that activate separately after a delay relative to recording onset and extinguish after a specified duration.  Timestamps are appended as metadata indicating when each component (torch, background) was activated or extinguished.  See attached diagram. 

![Screenshot 2024-04-09 at 4 11 36 PM](https://github.com/fahadhaque007/react-native-vision-camera/assets/15062524/370546e9-573d-431e-b958-d6573a32fb5a)




## Changes
This PR adds props to the Camera that define the onset and duration of two different torch levels.


## Tested on
iPhone12, 14, 15
Samsung Galaxy S23 Fan Edition


## Related issues

<!--
  Link related issues here.
  Examples:
    * Fixes #29
    * Closes #30
    * Resolves #5
-->
